### PR TITLE
Add Pygame intro screen

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
 # Wealth-Quest
-An open world financial literacy video game. 
+An open world financial literacy video game.
+
+## Intro Screen
+This repository includes a simple intro screen implemented with Pygame. The script displays the title **Wealth Quest** using a retro-style 16-bit look.
+
+### Running
+1. Install the dependencies (requires Python 3 and Pygame):
+   ```bash
+   pip install pygame
+   ```
+2. Run the intro screen:
+   ```bash
+   python3 intro_screen.py
+   ```

--- a/intro_screen.py
+++ b/intro_screen.py
@@ -1,0 +1,38 @@
+import pygame
+import sys
+
+WIDTH, HEIGHT = 800, 600
+
+# Initialize pygame
+pygame.init()
+
+# Set up the display
+screen = pygame.display.set_mode((WIDTH, HEIGHT))
+pygame.display.set_caption("Wealth Quest Intro")
+
+# Colors (16-bit style palette)
+BLACK = (0, 0, 0)
+WHITE = (255, 255, 255)
+
+# Load a pixel-style font
+font = pygame.font.Font(None, 72)  # Default font scaled up
+
+text = font.render("Wealth Quest", True, WHITE)
+text_rect = text.get_rect(center=(WIDTH // 2, HEIGHT // 2))
+
+clock = pygame.time.Clock()
+
+running = True
+while running:
+    for event in pygame.event.get():
+        if event.type == pygame.QUIT:
+            running = False
+
+    screen.fill(BLACK)
+    screen.blit(text, text_rect)
+    pygame.display.flip()
+    clock.tick(60)
+
+pygame.quit()
+sys.exit()
+


### PR DESCRIPTION
## Summary
- implement a simple Pygame intro screen with the title "Wealth Quest"
- update README with instructions on how to run the intro screen

## Testing
- `python3 intro_screen.py` *(fails: ModuleNotFoundError: No module named 'pygame')*


------
https://chatgpt.com/codex/tasks/task_e_684afe5174ac8326aeb2448c36c1664d