### PR TITLE
ADHD Focus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+focus.db
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,54 @@
-# Wealth-Quest
-An open world financial literacy video game. 
+# Focus RPG: ADHD Game Plan Toolkit
+
+This repo packages a no-frills ADHD action plan and a shippable FastAPI + HTMX app you can drop into Replit (or run locally) to track deep work reps, earn rewards, and deploy the "storm" rescue protocol when things get noisy.
+
+## Quick start
+
+```bash
+pip install -r requirements.txt
+uvicorn app.main:app --reload
+```
+
+Then open [http://127.0.0.1:8000](http://127.0.0.1:8000) to see the Today dashboard.
+
+## What you get
+
+- **Today dashboard** – capture micro-steps, see the top-five priorities, fire up a focus timer, and log distraction counts.
+- **Points + dopamine menu** – complete a focus block to bank points, then redeem them for tight dopamine hits with cooldowns so you don’t derail the day.
+- **ADHD storm protocol** – one click drops the four-step rescue checklist into view and logs the trigger so you can review patterns later.
+- **Stats snapshot** – total points, sessions logged, streak days, and distraction counts refresh automatically as you work.
+
+Everything runs on SQLite via SQLModel, so the data lives in `focus.db`. You can safely copy or back up that file whenever you need to reset.
+
+## API sketch
+
+| Method | Endpoint | Purpose |
+| --- | --- | --- |
+| `POST` | `/tasks` | Create a task (5–10 minute micro-step recommended). |
+| `GET` | `/tasks?status=open` | List tasks filtered by status. |
+| `PATCH` | `/tasks/{id}` | Update any task fields. |
+| `POST` | `/tasks/{id}/complete` | Mark a task done (used by the UI). |
+| `POST` | `/sessions/start` | Start a focus session for a task. |
+| `POST` | `/sessions/stop` | Stop a session, award points, log distractions. |
+| `POST` | `/sessions/{id}/distract` | Increment the distraction counter during a session. |
+| `GET` | `/stats/daily` | Pull totals for points, sessions, streak, and distractions. |
+| `POST` | `/rewards/redeem` | Spend points on a reward. |
+| `POST` | `/storm` | Log a trigger and get the storm protocol steps. |
+
+Default rewards are seeded on startup (espresso, meme scroll, etc.), and a placeholder user keeps things simple until you’re ready for multi-user auth.
+
+## ADHD game plan
+
+Pair the app with these daily/weekly anchors:
+
+- Sleep gate: 7–8h, consistent bed/wake.
+- Meds/therapy/coach: treat them like oxygen.
+- Move 20 minutes: walk, lift, stretch—anything.
+- Two deep work blocks (25–40 minutes, DND on).
+- 15-minute admin sweep to close loops.
+- Weekly: 30-minute planning, budget reset, body-double session.
+- Task rules: start tiny, timebox everything, split anything >40 minutes.
+- Storm protocol: 3-item rescue list → 5-minute start → body-double → reset with movement/cold water.
+- Dopamine menu: espresso, meme pass, pushups + music, 5-minute game, or 10 minutes outside.
+
+Track your streaks, watch the distraction count trend down, and iterate after 14 days.

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,530 @@
+from __future__ import annotations
+
+import json
+from datetime import date, datetime, timedelta
+from math import floor
+from pathlib import Path
+from typing import Annotated, Optional
+
+from fastapi import Depends, FastAPI, Form, HTTPException, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+from pydantic import BaseModel
+from sqlmodel import Field, Session, SQLModel, create_engine, select
+
+DATABASE_URL = "sqlite:///focus.db"
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+
+app = FastAPI(title="Focus RPG")
+app.mount("/static", StaticFiles(directory=Path(__file__).parent / "static"), name="static")
+templates = Jinja2Templates(directory=str(Path(__file__).parent / "templates"))
+templates.env.globals.update(datetime=datetime, timedelta=timedelta)
+
+
+class User(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+
+
+class Task(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    title: str
+    note: Optional[str] = ""
+    est_minutes: int = 10
+    context: str = "work"
+    due_date: Optional[str] = None
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    status: str = "open"
+    impact: int = 1
+    priority_score: int = 0
+
+
+class FocusSession(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    task_id: int
+    start: datetime
+    end: Optional[datetime] = None
+    duration_min: int = 0
+    completed_bool: bool = False
+    distract_count: int = 0
+
+
+class Reward(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    name: str
+    cost_points: int
+    cooldown_min: int = 0
+    last_redeemed_at: Optional[datetime] = None
+
+
+class PointLedger(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    delta: int
+    reason: str
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+
+
+class TriggerLog(SQLModel, table=True):
+    id: Optional[int] = Field(default=None, primary_key=True)
+    trigger_type: str
+    note: Optional[str] = None
+    timestamp: datetime = Field(default_factory=datetime.utcnow)
+
+
+class TaskCreate(BaseModel):
+    title: str
+    note: Optional[str] = None
+    est_minutes: int = 10
+    context: str = "work"
+    due_date: Optional[str] = None
+    impact: int = 1
+
+
+class TaskUpdate(BaseModel):
+    title: Optional[str] = None
+    note: Optional[str] = None
+    est_minutes: Optional[int] = None
+    context: Optional[str] = None
+    due_date: Optional[str] = None
+    status: Optional[str] = None
+    impact: Optional[int] = None
+
+
+class StormPayload(BaseModel):
+    trigger: Optional[str] = None
+    note: Optional[str] = None
+
+
+def get_session() -> Session:
+    with Session(engine) as session:
+        yield session
+
+
+SessionDep = Annotated[Session, Depends(get_session)]
+
+
+def init_db() -> None:
+    SQLModel.metadata.create_all(engine)
+    with Session(engine) as session:
+        if not session.exec(select(User)).first():
+            session.add(User(name="Solo Player"))
+        existing_rewards = session.exec(select(Reward)).all()
+        if not existing_rewards:
+            session.add_all(
+                [
+                    Reward(name="Espresso or fancy tea", cost_points=8, cooldown_min=60),
+                    Reward(name="One meme scroll pass", cost_points=6, cooldown_min=90),
+                    Reward(name="10 pushups + music break", cost_points=5, cooldown_min=45),
+                    Reward(name="5 minutes of game time", cost_points=7, cooldown_min=120),
+                    Reward(name="10 minutes outside", cost_points=9, cooldown_min=180),
+                ]
+            )
+        session.commit()
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    init_db()
+
+
+def parse_due_date(value: Optional[str]) -> Optional[date]:
+    if not value:
+        return None
+    try:
+        return datetime.strptime(value, "%Y-%m-%d").date()
+    except ValueError:
+        return None
+
+
+def compute_priority(task: Task) -> int:
+    today = datetime.utcnow().date()
+    due = parse_due_date(task.due_date)
+    is_due_today = 1 if due == today else 0
+    is_overdue = 1 if (due and due < today) else 0
+    freshness = 1 if (datetime.utcnow() - task.created_at).days <= 3 else 0
+    return (is_due_today * 3) + (is_overdue * 5) + task.impact + freshness
+
+
+def compute_points_balance(session: Session) -> int:
+    return sum(entry.delta for entry in session.exec(select(PointLedger)).all())
+
+
+@app.get("/", response_class=HTMLResponse)
+def home(request: Request, session: SessionDep) -> HTMLResponse:
+    tasks = (
+        session.exec(
+            select(Task)
+            .where(Task.status == "open")
+            .order_by(Task.priority_score.desc(), Task.created_at)
+            .limit(5)
+        ).all()
+    )
+    balance = compute_points_balance(session)
+    rewards = session.exec(select(Reward)).all()
+    stats = get_daily_stats(session)
+    return templates.TemplateResponse(
+        "today.html",
+        {
+            "request": request,
+            "tasks": tasks,
+            "balance": balance,
+            "rewards": rewards,
+            "stats": stats,
+        },
+    )
+
+
+@app.get("/tasks", response_model=list[Task])
+def list_tasks(session: SessionDep, status: str = "open") -> list[Task]:
+    statement = select(Task).where(Task.status == status).order_by(
+        Task.priority_score.desc(), Task.created_at
+    )
+    return session.exec(statement).all()
+
+
+def insert_task(session: Session, payload: TaskCreate) -> Task:
+    task = Task(**payload.model_dump())
+    task.priority_score = compute_priority(task)
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+@app.post("/tasks", response_model=Task)
+def create_task(payload: TaskCreate, session: SessionDep) -> Task:
+    return insert_task(session, payload)
+
+
+@app.patch("/tasks/{task_id}", response_model=Task)
+def update_task(task_id: int, payload: TaskUpdate, session: SessionDep) -> Task:
+    task = session.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    update_data = payload.model_dump(exclude_unset=True)
+    for key, value in update_data.items():
+        setattr(task, key, value)
+    task.priority_score = compute_priority(task)
+    session.add(task)
+    session.commit()
+    session.refresh(task)
+    return task
+
+
+@app.delete("/tasks/{task_id}")
+def delete_task(task_id: int, session: SessionDep) -> dict[str, str]:
+    task = session.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    session.delete(task)
+    session.commit()
+    return {"status": "deleted"}
+
+
+@app.post("/tasks/{task_id}/complete", response_class=HTMLResponse)
+def complete_task(task_id: int, request: Request, session: SessionDep) -> HTMLResponse:
+    task = session.get(Task, task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.status = "done"
+    session.add(task)
+    session.commit()
+    tasks = (
+        session.exec(
+            select(Task)
+            .where(Task.status == "open")
+            .order_by(Task.priority_score.desc(), Task.created_at)
+            .limit(5)
+        ).all()
+    )
+    response = templates.TemplateResponse(
+        "partials/task_list.html", {"request": request, "tasks": tasks}
+    )
+    response.headers["HX-Trigger"] = json.dumps({"stats:refresh": {}})
+    return response
+
+
+@app.post("/tasks/form", response_class=HTMLResponse)
+def create_task_form(
+    request: Request,
+    session: SessionDep,
+    title: Annotated[str, Form(...)],
+    note: Annotated[Optional[str], Form()] = None,
+    est_minutes: Annotated[int, Form()] = 10,
+    context: Annotated[str, Form()] = "work",
+    due_date: Annotated[Optional[str], Form()] = None,
+    impact: Annotated[int, Form()] = 1,
+) -> HTMLResponse:
+    payload = TaskCreate(
+        title=title,
+        note=note,
+        est_minutes=est_minutes,
+        context=context,
+        due_date=due_date,
+        impact=impact,
+    )
+    insert_task(session, payload)
+    tasks = (
+        session.exec(
+            select(Task)
+            .where(Task.status == "open")
+            .order_by(Task.priority_score.desc(), Task.created_at)
+            .limit(5)
+        ).all()
+    )
+    return templates.TemplateResponse(
+        "partials/task_list.html",
+        {"request": request, "tasks": tasks},
+    )
+
+
+class SessionStartPayload(BaseModel):
+    task_id: int
+
+
+class SessionStopPayload(BaseModel):
+    session_id: int
+    completed: bool = False
+    distracts: int = 0
+    est_minutes: int = 25
+
+
+@app.post("/sessions/start")
+def start_session(payload: SessionStartPayload, session: SessionDep) -> dict[str, int | str]:
+    task = session.get(Task, payload.task_id)
+    if not task:
+        raise HTTPException(status_code=404, detail="Task not found")
+    task.status = "doing"
+    focus_session = FocusSession(task_id=payload.task_id, start=datetime.utcnow())
+    session.add(focus_session)
+    session.add(task)
+    session.commit()
+    session.refresh(focus_session)
+    return {"session_id": focus_session.id, "task": task.title}
+
+
+@app.post("/sessions/stop")
+def stop_session(payload: SessionStopPayload, session: SessionDep) -> dict[str, int]:
+    focus_session = session.get(FocusSession, payload.session_id)
+    if not focus_session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    if focus_session.end:
+        return {"earned_points": 0, "duration_min": focus_session.duration_min}
+
+    focus_session.end = datetime.utcnow()
+    focus_session.duration_min = max(
+        1, int((focus_session.end - focus_session.start).total_seconds() // 60)
+    )
+    focus_session.completed_bool = payload.completed
+    focus_session.distract_count = payload.distracts
+
+    task = session.get(Task, focus_session.task_id)
+    points = 0
+    if task:
+        if payload.completed:
+            task.status = "done"
+            points = 5 + floor(payload.est_minutes / 10)
+            due = parse_due_date(task.due_date)
+            if due and focus_session.end.date() <= due:
+                points += 3
+        else:
+            task.status = "open"
+        session.add(task)
+
+    session.add(focus_session)
+
+    if points:
+        ledger_entry = PointLedger(delta=points, reason="completed_focus_session")
+        session.add(ledger_entry)
+
+    session.commit()
+    session.refresh(focus_session)
+    return {"earned_points": points, "duration_min": focus_session.duration_min}
+
+
+@app.post("/sessions/{session_id}/distract")
+def increment_distraction(session_id: int, session: SessionDep) -> dict[str, int]:
+    focus_session = session.get(FocusSession, session_id)
+    if not focus_session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    focus_session.distract_count += 1
+    session.add(focus_session)
+    session.commit()
+    session.refresh(focus_session)
+    return {"distract_count": focus_session.distract_count}
+
+
+class RewardCreate(BaseModel):
+    name: str
+    cost_points: int
+    cooldown_min: int = 0
+
+
+@app.get("/rewards", response_model=list[Reward])
+def list_rewards(session: SessionDep) -> list[Reward]:
+    return session.exec(select(Reward)).all()
+
+
+@app.post("/rewards", response_model=Reward)
+def create_reward(payload: RewardCreate, session: SessionDep) -> Reward:
+    reward = Reward(**payload.model_dump())
+    session.add(reward)
+    session.commit()
+    session.refresh(reward)
+    return reward
+
+
+class RedeemPayload(BaseModel):
+    reward_id: int
+
+
+@app.post("/rewards/redeem")
+def redeem_reward(
+    payload: RedeemPayload, request: Request, session: SessionDep
+) -> HTMLResponse | dict[str, str | int]:
+    reward = session.get(Reward, payload.reward_id)
+    if not reward:
+        raise HTTPException(status_code=404, detail="Reward not found")
+    balance = compute_points_balance(session)
+    if balance < reward.cost_points:
+        raise HTTPException(status_code=400, detail="Not enough points")
+    if reward.last_redeemed_at:
+        cooldown = reward.last_redeemed_at + timedelta(minutes=reward.cooldown_min)
+        if datetime.utcnow() < cooldown:
+            raise HTTPException(status_code=400, detail="Reward on cooldown")
+    ledger_entry = PointLedger(delta=-reward.cost_points, reason=f"redeem:{reward.name}")
+    reward.last_redeemed_at = datetime.utcnow()
+    session.add_all([ledger_entry, reward])
+    session.commit()
+    new_balance = compute_points_balance(session)
+
+    if request.headers.get("HX-Request"):
+        rewards = session.exec(select(Reward)).all()
+        response = templates.TemplateResponse(
+            "partials/reward_list.html",
+            {"request": request, "rewards": rewards, "balance": new_balance},
+        )
+        response.headers["HX-Trigger"] = json.dumps(
+            {
+                "points:update": {"balance": new_balance},
+                "stats:refresh": {},
+            }
+        )
+        return response
+
+    return {"status": "ok", "balance": new_balance}
+
+
+@app.get("/stats/daily")
+def daily_stats(session: SessionDep) -> dict[str, int | float]:
+    stats = get_daily_stats(session)
+    return stats
+
+
+def get_daily_stats(session: Session) -> dict[str, int | float]:
+    today = datetime.utcnow().date()
+    all_points = session.exec(select(PointLedger)).all()
+    total_points = sum(entry.delta for entry in all_points)
+    tasks_done = session.exec(select(Task).where(Task.status == "done")).all()
+    total_sessions = session.exec(select(FocusSession)).all()
+    streak = compute_completion_streak(session)
+    distractions_today = sum(
+        sess.distract_count
+        for sess in total_sessions
+        if sess.end and sess.end.date() == today
+    )
+    return {
+        "total_points": total_points,
+        "tasks_done": len(tasks_done),
+        "sessions_logged": len(total_sessions),
+        "streak_days": streak,
+        "distractions_today": distractions_today,
+    }
+
+
+def compute_completion_streak(session: Session) -> int:
+    completed_sessions = session.exec(
+        select(FocusSession).where(
+            FocusSession.completed_bool == True,  # noqa: E712
+            FocusSession.end.is_not(None),
+        )
+    ).all()
+    completed_dates = {
+        sess.end.date()
+        for sess in completed_sessions
+        if sess.end and sess.completed_bool
+    }
+    if not completed_dates:
+        return 0
+    streak = 0
+    current_day = datetime.utcnow().date()
+    while current_day in completed_dates:
+        streak += 1
+        current_day = current_day - timedelta(days=1)
+    return streak
+
+
+@app.post("/storm")
+def storm(
+    payload: StormPayload, request: Request, session: SessionDep
+) -> HTMLResponse | dict[str, list[str]]:
+    session.add(
+        TriggerLog(
+            trigger_type=payload.trigger or "storm",
+            note=payload.note,
+        )
+    )
+    session.commit()
+    checklist = [
+        "Write a 3-item rescue list on paper.",
+        "Spend 5 minutes on the first item.",
+        "Ping a buddy or schedule a body-double session.",
+        "If still stuck: 10 jumping jacks, cold water, then back for 5 minutes.",
+    ]
+    if request.headers.get("HX-Request"):
+        items = "".join(f"<li>{step}</li>" for step in checklist)
+        response = HTMLResponse(items)
+        response.headers["HX-Trigger"] = json.dumps({"stats:refresh": {}})
+        return response
+    return {"protocol": checklist}
+
+
+@app.get("/storm/logs")
+def storm_logs(session: SessionDep) -> list[TriggerLog]:
+    return session.exec(select(TriggerLog).order_by(TriggerLog.timestamp.desc())).all()
+
+
+@app.get("/partials/task-list", response_class=HTMLResponse)
+def task_list_partial(request: Request, session: SessionDep) -> HTMLResponse:
+    tasks = (
+        session.exec(
+            select(Task)
+            .where(Task.status == "open")
+            .order_by(Task.priority_score.desc(), Task.created_at)
+            .limit(5)
+        ).all()
+    )
+    return templates.TemplateResponse(
+        "partials/task_list.html",
+        {"request": request, "tasks": tasks},
+    )
+
+
+@app.get("/partials/rewards", response_class=HTMLResponse)
+def rewards_partial(request: Request, session: SessionDep) -> HTMLResponse:
+    rewards = session.exec(select(Reward)).all()
+    balance = compute_points_balance(session)
+    return templates.TemplateResponse(
+        "partials/reward_list.html",
+        {"request": request, "rewards": rewards, "balance": balance},
+    )
+
+
+@app.get("/partials/stats", response_class=HTMLResponse)
+def stats_partial(request: Request, session: SessionDep) -> HTMLResponse:
+    stats = get_daily_stats(session)
+    return templates.TemplateResponse(
+        "partials/stats.html",
+        {"request": request, "stats": stats},
+    )

--- a/app/static/styles.css
+++ b/app/static/styles.css
@@ -1,0 +1,135 @@
+body {
+  background: #101728;
+  color: #f5f7ff;
+  font-family: "Inter", system-ui, sans-serif;
+}
+
+.container {
+  padding-bottom: 4rem;
+}
+
+.header {
+  margin: 2rem 0 1rem 0;
+}
+
+.tagline {
+  color: #cbd5ff;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-bottom: 2rem;
+}
+
+.task-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 1rem;
+}
+
+.task-list li {
+  background: #1c2541;
+  border-radius: 12px;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: start;
+}
+
+.task-list .meta,
+.task-list .note,
+.task-list .due {
+  margin: 0.25rem 0;
+  color: #cbd5ff;
+}
+
+.task-list .note {
+  font-size: 0.9rem;
+}
+
+.task-list .due {
+  font-weight: 600;
+  color: #ffb347;
+}
+
+.task-list .actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.balance {
+  font-size: 1.2rem;
+}
+
+.reward-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.75rem;
+}
+
+.reward {
+  background: #2b3561;
+  border-radius: 10px;
+  padding: 0.75rem;
+  text-align: left;
+}
+
+.reward strong {
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+.timer {
+  background: #1c2541;
+  border-radius: 12px;
+  padding: 1rem;
+}
+
+.countdown {
+  font-size: 2.5rem;
+  margin: 0.5rem 0 1rem 0;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.storm-steps {
+  margin-top: 1rem;
+  color: #cbd5ff;
+  padding-left: 1.5rem;
+}
+
+.stats p {
+  margin: 0.25rem 0;
+}
+
+.toast {
+  position: fixed;
+  bottom: 1.5rem;
+  right: 1.5rem;
+  background: #38bdf8;
+  color: #031026;
+  padding: 0.75rem 1rem;
+  border-radius: 999px;
+  box-shadow: 0 10px 30px rgba(3, 16, 38, 0.4);
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .task-list li {
+    flex-direction: column;
+  }
+
+  .button-row {
+    flex-direction: column;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" x-data>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Focus RPG</title>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@1/css/pico.min.css" />
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <script src="https://unpkg.com/alpinejs@3.x.x" defer></script>
+    <link rel="stylesheet" href="{{ url_for('static', path='styles.css') }}" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="header">
+        <h1>Focus RPG</h1>
+        <p class="tagline">Finish tiny quests, earn dopamine, keep the chaos low.</p>
+      </header>
+      {% block content %}{% endblock %}
+    </main>
+  </body>
+</html>

--- a/app/templates/partials/reward_list.html
+++ b/app/templates/partials/reward_list.html
@@ -1,0 +1,21 @@
+<div class="reward-grid">
+  {% if rewards %}
+    {% for reward in rewards %}
+      {% set on_cooldown = reward.last_redeemed_at and (reward.last_redeemed_at + timedelta(minutes=reward.cooldown_min) > datetime.utcnow()) %}
+      <button
+        hx-post="/rewards/redeem"
+        hx-vals='{"reward_id": {{ reward.id }} }'
+        hx-target="#reward-list"
+        hx-swap="outerHTML"
+        {% if balance < reward.cost_points or on_cooldown %}disabled{% endif %}
+        class="reward"
+      >
+        <strong>{{ reward.name }}</strong>
+        <span>{{ reward.cost_points }} pts</span>
+        {% if on_cooldown %}<small>Cooldown</small>{% endif %}
+      </button>
+    {% endfor %}
+  {% else %}
+    <p class="muted">No rewards yet. Seed them in the DB or add via the API.</p>
+  {% endif %}
+</div>

--- a/app/templates/partials/stats.html
+++ b/app/templates/partials/stats.html
@@ -1,0 +1,7 @@
+<div class="stats">
+  <p><strong>Total points:</strong> {{ stats.total_points }}</p>
+  <p><strong>Sessions logged:</strong> {{ stats.sessions_logged }}</p>
+  <p><strong>Tasks done:</strong> {{ stats.tasks_done }}</p>
+  <p><strong>Streak:</strong> {{ stats.streak_days }} day(s)</p>
+  <p><strong>Distractions today:</strong> {{ stats.distractions_today }}</p>
+</div>

--- a/app/templates/partials/task_list.html
+++ b/app/templates/partials/task_list.html
@@ -1,0 +1,20 @@
+<ul class="task-list">
+  {% if tasks %}
+    {% for task in tasks %}
+      <li>
+        <div>
+          <h3>{{ task.title }}</h3>
+          <p class="meta">{{ task.context|capitalize }} • est {{ task.est_minutes }} min • priority {{ task.priority_score }}</p>
+          {% if task.note %}<p class="note">{{ task.note }}</p>{% endif %}
+          {% if task.due_date %}<p class="due">Due {{ task.due_date }}</p>{% endif %}
+        </div>
+        <div class="actions">
+          <button data-task="{{ task.id }}" data-est="{{ task.est_minutes }}">Start Focus</button>
+          <button class="secondary" hx-post="/tasks/{{ task.id }}/complete" hx-target="#task-list" hx-swap="outerHTML">Mark Done</button>
+        </div>
+      </li>
+    {% endfor %}
+  {% else %}
+    <li class="empty">All clear. Capture something tiny or redeem a reward.</li>
+  {% endif %}
+</ul>

--- a/app/templates/today.html
+++ b/app/templates/today.html
@@ -1,0 +1,221 @@
+{% extends "base.html" %}
+{% block content %}
+<section class="grid">
+  <article>
+    <h2>Quick Capture</h2>
+    <form hx-post="/tasks/form" hx-target="#task-list" hx-swap="outerHTML" hx-on::afterRequest="this.reset()" class="stack">
+      <label>
+        Title
+        <input type="text" name="title" required placeholder="What is the next 5-minute step?" />
+      </label>
+      <div class="grid">
+        <label>
+          Estimate (min)
+          <input type="number" name="est_minutes" min="5" step="5" value="25" />
+        </label>
+        <label>
+          Impact (1-3)
+          <input type="number" name="impact" min="1" max="3" value="1" />
+        </label>
+      </div>
+      <div class="grid">
+        <label>
+          Context
+          <select name="context">
+            <option value="work">Work</option>
+            <option value="home">Home</option>
+            <option value="admin">Admin</option>
+          </select>
+        </label>
+        <label>
+          Due date
+          <input type="date" name="due_date" />
+        </label>
+      </div>
+      <label>
+        Notes
+        <textarea name="note" rows="2" placeholder="Tiny instructions for Future You"></textarea>
+      </label>
+      <button type="submit">Add micro-step</button>
+    </form>
+  </article>
+  <article>
+    <h2>Points &amp; Rewards</h2>
+    <p class="balance">Current points: <strong id="points-balance">{{ balance }}</strong></p>
+    <div id="reward-list" hx-get="/partials/rewards" hx-trigger="load" hx-target="#reward-list" hx-swap="outerHTML">
+      {% include "partials/reward_list.html" %}
+    </div>
+  </article>
+</section>
+
+<section class="grid">
+  <article>
+    <div class="flex-between">
+      <h2>Today&apos;s Top 5</h2>
+      <button class="secondary" hx-get="/partials/task-list" hx-target="#task-list" hx-swap="outerHTML">Refresh</button>
+    </div>
+    <div id="task-list">
+      {% include "partials/task_list.html" %}
+    </div>
+  </article>
+  <article x-data="focusTimer()" @session-start.window="start($event.detail)">
+    <h2>Focus Timer</h2>
+    <template x-if="!active">
+      <p class="muted">Pick a task and smash the Start Focus button.</p>
+    </template>
+    <template x-if="active">
+      <div class="timer">
+        <h3 x-text="taskTitle"></h3>
+        <p class="countdown" x-text="formattedTime"></p>
+        <div class="button-row">
+          <button @click="markDistracted" type="button">I got distracted (x<span x-text="distracts"></span>)</button>
+          <button class="secondary" @click="finish(false)" type="button">Pause</button>
+          <button class="contrast" @click="finish(true)" type="button">Done</button>
+        </div>
+      </div>
+    </template>
+  </article>
+</section>
+
+<section class="grid">
+  <article>
+    <h2>Storm Protocol</h2>
+    <p>Spinning out? Trigger the rescue steps.</p>
+    <button
+      hx-post="/storm"
+      hx-trigger="click"
+      hx-target="#storm-steps"
+      hx-swap="innerHTML"
+      type="button"
+      class="contrast"
+    >
+      Deploy Storm Protocol
+    </button>
+    <ol id="storm-steps" class="storm-steps"></ol>
+  </article>
+  <article>
+    <h2>Stats Snapshot</h2>
+    <div id="stats-panel" hx-get="/partials/stats" hx-trigger="load, every 120s" hx-target="#stats-panel" hx-swap="outerHTML">
+      {% include "partials/stats.html" %}
+    </div>
+  </article>
+</section>
+
+<script>
+  function focusTimer() {
+    return {
+      active: false,
+      sessionId: null,
+      taskTitle: "",
+      expectedMinutes: 25,
+      startTime: null,
+      distracts: 0,
+      interval: null,
+      ticker: 0,
+      get formattedTime() {
+        if (!this.startTime) return "00:00";
+        this.ticker;
+        const diff = Math.floor((Date.now() - this.startTime) / 1000);
+        const remaining = Math.max(0, this.expectedMinutes * 60 - diff);
+        const minutes = String(Math.floor(remaining / 60)).padStart(2, "0");
+        const seconds = String(remaining % 60).padStart(2, "0");
+        return `${minutes}:${seconds}`;
+      },
+      start(data) {
+        this.active = true;
+        this.sessionId = data.session_id;
+        this.taskTitle = data.task;
+        this.expectedMinutes = data.est_minutes || 25;
+        this.startTime = Date.now();
+        this.distracts = 0;
+        this.ticker = 0;
+        this.interval = setInterval(() => {
+          this.ticker++;
+        }, 1000);
+      },
+      async finish(completed) {
+        if (!this.sessionId) return;
+        const response = await fetch("/sessions/stop", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            session_id: this.sessionId,
+            completed,
+            distracts: this.distracts,
+            est_minutes: this.expectedMinutes,
+          }),
+        });
+        if (response.ok) {
+          const data = await response.json();
+          this.$dispatch("session-complete", data);
+          htmx.ajax("GET", "/partials/task-list", { target: "#task-list", swap: "outerHTML" });
+          htmx.ajax("GET", "/partials/rewards", { target: "#reward-list", swap: "outerHTML" });
+          htmx.ajax("GET", "/partials/stats", { target: "#stats-panel", swap: "outerHTML" });
+        }
+        this.stop();
+      },
+      stop() {
+        this.active = false;
+        this.sessionId = null;
+        this.taskTitle = "";
+        this.startTime = null;
+        this.distracts = 0;
+        this.ticker = 0;
+        if (this.interval) {
+          clearInterval(this.interval);
+          this.interval = null;
+        }
+      },
+      async markDistracted() {
+        if (!this.sessionId) return;
+        const response = await fetch(`/sessions/${this.sessionId}/distract`, {
+          method: "POST",
+        });
+        if (response.ok) {
+          const data = await response.json();
+          this.distracts = data.distract_count;
+        }
+      },
+    };
+  }
+
+  document.body.addEventListener("click", async (event) => {
+    const startBtn = event.target.closest("button[data-task]");
+    if (!startBtn) return;
+    const taskId = Number(startBtn.dataset.task);
+    const est = Number(startBtn.dataset.est || "25");
+    const response = await fetch("/sessions/start", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ task_id: taskId }),
+    });
+    if (response.ok) {
+      const data = await response.json();
+      data.est_minutes = est;
+      window.dispatchEvent(new CustomEvent("session-start", { detail: data }));
+      htmx.ajax("GET", "/partials/task-list", { target: "#task-list", swap: "outerHTML" });
+    }
+  });
+
+  document.body.addEventListener("session-complete", (event) => {
+    if (!event.detail) return;
+    const toast = document.createElement("div");
+    toast.className = "toast";
+    toast.textContent = `Session logged! +${event.detail.earned_points} points.`;
+    document.body.appendChild(toast);
+    setTimeout(() => toast.remove(), 2500);
+  });
+
+  document.body.addEventListener("points:update", (event) => {
+    const balance = event.detail?.balance;
+    if (typeof balance === "number") {
+      const el = document.getElementById("points-balance");
+      if (el) el.textContent = balance;
+    }
+  });
+
+  document.body.addEventListener("stats:refresh", () => {
+    htmx.ajax("GET", "/partials/stats", { target: "#stats-panel", swap: "outerHTML" });
+  });
+</script>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+sqlmodel==0.0.14
+jinja2==3.1.3


### PR DESCRIPTION
## Summary
- add a FastAPI + SQLModel backend for tasks, focus sessions, rewards, stats, and the storm protocol
- create HTMX/Alpine.js templates and styling for the Today dashboard, focus timer, rewards, and stats panels
- document the ADHD routine, running instructions, and dependencies; ignore generated DB/cache files

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dbdc04d4f48326a177da0b3b4221e9